### PR TITLE
Fix : Drawer menu items are not centered

### DIFF
--- a/lib/Drawer/Item.js
+++ b/lib/Drawer/Item.js
@@ -59,10 +59,11 @@ const styles = {
     },
     icon: {
         position: 'relative',
-        top: -2
+        top: -1
     },
     value: {
         flex: 1,
-        paddingLeft: 34
+        paddingLeft: 34,
+        top: 1
     }
 };

--- a/lib/Drawer/Item.js
+++ b/lib/Drawer/Item.js
@@ -64,6 +64,6 @@ const styles = {
     value: {
         flex: 1,
         paddingLeft: 34,
-        top: 1
+        top: 2
     }
 };

--- a/lib/Drawer/Item.js
+++ b/lib/Drawer/Item.js
@@ -59,7 +59,6 @@ const styles = {
     },
     icon: {
         position: 'relative',
-        top: -1
     },
     value: {
         flex: 1,


### PR DESCRIPTION
Fix for : **Drawer menu items are not centered**

As discussed on #5 .
Here is a screenshot after the fix-

![final fix](https://cloud.githubusercontent.com/assets/1252941/12010170/8354c9cc-acc1-11e5-8e75-05d9c46ac2c2.png)

