### PR TITLE
Drawer menu items with label support

### DIFF
--- a/lib/Drawer/Item.js
+++ b/lib/Drawer/Item.js
@@ -7,6 +7,7 @@ export default class Item extends Component {
     static propTypes = {
         icon: PropTypes.string,
         value: PropTypes.string.isRequired,
+        label: PropTypes.string,
         onPress: PropTypes.func,
         active: PropTypes.bool,
         disabled: PropTypes.bool
@@ -18,7 +19,7 @@ export default class Item extends Component {
     };
 
     render() {
-        const { icon, value, onPress } = this.props;
+        const { icon, value, label, onPress } = this.props;
 
         return (
             <TouchableHighlight
@@ -38,6 +39,11 @@ export default class Item extends Component {
                             {value}
                         </Text>
 
+                    </View>
+                    <View style={styles.label}>
+                        <Text style={[TYPO.paperFontBody2, { color: 'rgba(0,0,0,.87)' }]}>
+                            {label}
+                        </Text>
                     </View>
                 </View>
             </TouchableHighlight>
@@ -63,6 +69,9 @@ const styles = {
     value: {
         flex: 1,
         paddingLeft: 34,
+        top: 2
+    },
+    label: {
         top: 2
     }
 };


### PR DESCRIPTION
Drawer menu items now supports Labels.

**Feature summary-**

The Drawer library will get a new prop called **"label"** from user's code.

The user can send a number or a string based on his needs.
Examples -
a. *Number*, **25** can indicate the count
b. *String, **"Updated!"** or **"new"** can indicate something new has come up in that section.

Usage example-
```
<Drawer.Item
    icon="radio-button-checked"
    value="RadioButtons"
    label="8"
    onPress={() => this.changeScene('RadioButtons')}
/>
```

**Screenshot-**


![drawer labels](https://cloud.githubusercontent.com/assets/1252941/12010398/42b993d4-accb-11e5-81fb-e5facd7e9894.png)
