### PR TITLE
Advanced styling for Toolbar

### DIFF
--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -11,11 +11,14 @@ export default class Toolbar extends Component {
         theme: PropTypes.oneOf(THEME_NAME),
         primary: PropTypes.oneOf(PRIMARY_COLORS),
         style: PropTypes.object,
+        leftIconStyle: PropTypes.object,
+        rightIconStyle: PropTypes.object,
         elevation: PropTypes.number,
         overrides: PropTypes.shape({
             backgroundColor: PropTypes.string,
             titleColor: PropTypes.string,
-            iconColor: PropTypes.string
+            leftIconColor: PropTypes.string,
+            rightIconColor: PropTypes.string
         }),
         icon: PropTypes.string,
         onIconPress: PropTypes.func,
@@ -33,18 +36,20 @@ export default class Toolbar extends Component {
     };
 
     render() {
-        const { title, theme, primary, style, elevation, overrides, icon, onIconPress, actions } = this.props;
+        const { title, theme, primary, style, leftIconStyle, rightIconStyle, elevation, overrides, icon, onIconPress, actions } = this.props;
 
         const themeMap = {
             light: {
                 backgroundColor: '#ffffff',
                 color: 'rgba(0,0,0,.87)',
-                iconColor: 'rgba(0,0,0,.54)'
+                leftIconColor: 'rgba(0,0,0,.54)',
+                rightIconColor: 'rgba(0,0,0,.54)'
             },
             dark: {
                 backgroundColor: getColor(primary),
                 color: 'rgba(255,255,255,.87)',
-                iconColor: 'rgba(255,255,255,.87)'
+                leftIconColor: 'rgba(255,255,255,.87)',
+                rightIconColor: 'rgba(255,255,255,.87)'
             }
         };
 
@@ -56,7 +61,8 @@ export default class Toolbar extends Component {
         const styleMap = {
             backgroundColor: overrides && overrides.backgroundColor ? getColor(overrides.backgroundColor) : themeMap[theme].backgroundColor,
             color: overrides && overrides.color ? getColor(overrides.color) : themeMap[theme].color,
-            iconColor: overrides && overrides.iconColor ? getColor(overrides.iconColor) : themeMap[theme].iconColor,
+            leftIconColor: overrides && overrides.leftIconColor ? getColor(overrides.leftIconColor) : themeMap[theme].leftIconColor,
+            rightIconColor: overrides && overrides.rightIconColor ? getColor(overrides.rightIconColor) : themeMap[theme].rightIconColor
         };
 
         return (
@@ -64,13 +70,13 @@ export default class Toolbar extends Component {
                 {
                     icon && (
                         <IconToggle
-                            color={styleMap.iconColor}
+                            color={styleMap.leftIconColor}
                             onPress={onIconPress}
                         >
                             <Icon name={icon || 'menu'}
                                   size={24}
-                                  color={styleMap.iconColor}
-                                  style={styles.icon}
+                                  color={styleMap.leftIconColor}
+                                  style={[styles.leftIcon, leftIconStyle]}
                             />
                         </IconToggle>
                     )
@@ -90,15 +96,15 @@ export default class Toolbar extends Component {
                         return (
                             <IconToggle
                                 key={i}
-                                color={styleMap.iconColor}
+                                color={styleMap.rightIconColor}
                                 badge={action.badge}
                                 onPress={action.onPress}
                                 disabled={action.disabled}
                             >
                                 <Icon name={action.icon}
                                       size={24}
-                                      color={styleMap.iconColor}
-                                      style={[styles.icon, action.disabled ? { opacity: opacityMap[theme] } : null]}
+                                      color={styleMap.rightIconColor}
+                                      style={[styles.rightIcon, rightIconStyle, action.disabled ? { opacity: opacityMap[theme] } : null]}
                                 />
                             </IconToggle>
                         );
@@ -123,7 +129,11 @@ const styles = {
         flex: 1,
         marginLeft: 16
     },
-    icon: {
-        margin: 10
+    leftIcon: {
+        marginLeft: 16,
+        marginRight: 8
+    },
+    rightIcon: {
+        margin: 16
     }
 };


### PR DESCRIPTION
First of all, according to [Material Design Guidelines](https://www.google.com/design/spec/layout/structure.html#structure-app-bar), there should be other padding values for Toolbar icons (look at [this image](https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B6Okdz75tqQsLUFJUnFlRHVhUVU/layout_structure_appbar_metrics1.png) with correct values).
Secondly, I think it is a great idea to allow user to customise these values, that's why I've added leftIconStyle and rightIconStyle to propTypes map.