### PR TITLE
Improvements for Card: clickable card, more properties, Card/Body.js bugfix

### DIFF
--- a/lib/Card/Body.js
+++ b/lib/Card/Body.js
@@ -1,12 +1,8 @@
 import React, { Component, StyleSheet, PropTypes, View } from 'react-native';
 
-import { COLOR } from '../config';
-
-
 export default class Body extends Component {
 
     static propTypes = {
-        theme: PropTypes.string,
         children: PropTypes.node.isRequired
     };
 
@@ -14,7 +10,7 @@ export default class Body extends Component {
         const { theme, children } = this.props;
 
         return (
-            <View style={[styles.container, theme && { backgroundColor: COLOR[theme].color }]}>
+            <View style={ styles.container }>
                 {children}
             </View>
         );

--- a/lib/Card/index.js
+++ b/lib/Card/index.js
@@ -1,19 +1,30 @@
-import React, { Component, PropTypes, View } from 'react-native';
-import { isCompatible } from '../helpers';
+import React, { Component, PropTypes, View, TouchableNativeFeedback } from 'react-native';
+import Ripple from '../polyfill/Ripple';
+import { getColor, isCompatible } from '../helpers';
 
 import Media from './Media';
 import Body from './Body';
 import Actions from './Actions';
 
+import { COLOR } from '../config';
+
 export default class Card extends Component {
 
     static propTypes = {
+        theme: PropTypes.string,
+        overrides: PropTypes.shape({
+            backgroundColor: PropTypes.string,
+            rippleColor: PropTypes.string
+        }),
         elevation: PropTypes.number,
+        disabled: PropTypes.bool,
+        onPress: PropTypes.func,
         children: PropTypes.node.isRequired
     };
 
     static defaultProps = {
-        elevation: 2
+        elevation: 2,
+        disabled: false
     };
 
     static Media = Media;
@@ -23,20 +34,65 @@ export default class Card extends Component {
     static Actions = Actions;
 
     render() {
-        const { elevation, children } = this.props;
+        const { theme, overrides, elevation, disabled, onPress, children } = this.props;
 
-        return (
-            <View style={[
+        const cardStyle = (() => {
+            return [
                 styles.container, {
                     elevation
                 }, !isCompatible('elevation') && {
                     borderWidth: 1,
                     borderColor: 'rgba(0,0,0,.12)'
-                }]}
+                }, theme && {
+                    backgroundColor: COLOR[theme].color
+                }, overrides && overrides.backgroundColor && {
+                    backgroundColor: overrides.backgroundColor
+                }
+            ];
+        })();
+
+
+        if (onPress == null || disabled) {
+            return (
+                <View style={cardStyle}>
+                    {children}
+                </View>
+            );
+        }
+
+        const defaultRippleColor = 'rgba(153,153,153,.4)';
+        const rippleColor = (() => {
+            if (disabled || !(overrides && overrides.rippleColor)) {
+                return defaultRippleColor;
+            }
+
+            return getColor(overrides.rippleColor)
+        })();
+
+        if (!isCompatible('TouchableNativeFeedback')) {
+            return (
+                <Ripple
+                    rippleColor={rippleColor}
+                    onPress={onPress}
+                >
+                    <View style={cardStyle}>
+                        {children}
+                    </View>
+                </Ripple>
+            )
+        }
+
+        return (
+            <TouchableNativeFeedback
+                background={TouchableNativeFeedback.Ripple(rippleColor)}
+                onPress={onPress}
             >
-                {children}
-            </View>
+                <View style={cardStyle}>
+                    {children}
+                </View>
+            </TouchableNativeFeedback>
         );
+
     }
 
 }


### PR DESCRIPTION
Hello one more time and thanks for the awesome library.

I've found and fixed one small Card bug.
The problem is current version of Card Body allows to specify theme, but parent container has padding, and for that reason there is no way to apply theme to the whole card. But it is really easy to fix this bug — I just moved theme property to Card/index.js.
I've also added an ability to override card color, because there may be a situation when user don't want to use predefined colors.

One more thing: I've added an ability to specify onPress function for Card, because sometimes we want card to be clickable (For example, take a look at [this image](https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0Bzhp5Z4wHba3am9VWWFlbHVJNDg/components_cards3.png) from [Card Design Guidelines](https://www.google.com/design/spec/components/cards.html)).