### PR TITLE
Custom style for Card

### DIFF
--- a/lib/Card/index.js
+++ b/lib/Card/index.js
@@ -19,7 +19,8 @@ export default class Card extends Component {
         elevation: PropTypes.number,
         disabled: PropTypes.bool,
         onPress: PropTypes.func,
-        children: PropTypes.node.isRequired
+        children: PropTypes.node.isRequired,
+        style: PropTypes.object
     };
 
     static defaultProps = {
@@ -34,7 +35,7 @@ export default class Card extends Component {
     static Actions = Actions;
 
     render() {
-        const { theme, overrides, elevation, disabled, onPress, children } = this.props;
+        const { theme, overrides, elevation, disabled, onPress, children, style } = this.props;
 
         const cardStyle = (() => {
             return [
@@ -47,7 +48,7 @@ export default class Card extends Component {
                     backgroundColor: COLOR[theme].color
                 }, overrides && overrides.backgroundColor && {
                     backgroundColor: overrides.backgroundColor
-                }
+                }, style
             ];
         })();
 


### PR DESCRIPTION
Hey.

I've added an ability to assign custom style object for Card (the same way you do it for Toolbar and other UI elements).
I think that in future we should create custom PropTypes and move most of these attributes to PropTypes (like that: https://github.com/bretdabaker/react-native-vs-charts/blob/master/lib/DataPropType.js), but now it is good idea to give user an ability to customize, for example, margins for Card.

Hope you will find it useful, and thanks again for this library :+1: 