### PR TITLE
moved the order styles are applied so they can be overridden.  

### DIFF
--- a/lib/Divider.js
+++ b/lib/Divider.js
@@ -21,10 +21,10 @@ export default class Divider extends Component {
             <View
                 style={[
                     styles.divider,
-                    style,
                     inset && { marginLeft: 72 }, {
                         backgroundColor: theme === 'light' ? 'rgba(0,0,0,.12)' : 'rgba(255,255,255,.12)'
                     },
+                    style
                 ]}
             />
         );


### PR DESCRIPTION
we are using this on iOS and don't get the native android text input underlines. this allows us to set the color accordingly