### PR TITLE
Allow border styling via props

### DIFF
--- a/lib/Avatar.js
+++ b/lib/Avatar.js
@@ -10,26 +10,42 @@ export default class Avatar extends Component {
         size: PropTypes.number,
         color: PropTypes.string,
         backgroundColor: PropTypes.string,
-        text: PropTypes.string
+        text: PropTypes.string,
+        borderRadius: PropTypes.number,
+        borderColor: PropTypes.string,
+        borderWidth: PropTypes.number
     };
 
     static defaultProps = {
         size: 40,
         color: '#ffffff',
-        backgroundColor: getColor('paperGrey500')
+        backgroundColor: getColor('paperGrey500'),
+        borderRadius: 40 / 2,
+        borderColor: 'rgba(0,0,0,.1)',
+        borderWidth: 1
     };
 
     render() {
-        const { image, icon, size, color, backgroundColor, text } = this.props;
+        const {
+            image,
+            icon,
+            size,
+            color,
+            backgroundColor,
+            text,
+            borderRadius,
+            borderColor,
+            borderWidth
+        } = this.props;
 
         if (image) {
             return React.cloneElement(image, {
                 style: {
                     width: size,
                     height: size,
-                    borderRadius: size / 2,
-                    borderColor: 'rgba(0,0,0,.1)',
-                    borderWidth: 1
+                    borderRadius: borderRadius,
+                    borderColor: borderColor,
+                    borderWidth: borderWidth
                 }
             });
         }
@@ -37,7 +53,7 @@ export default class Avatar extends Component {
         if (icon) {
             return (
                 <View style={{ flex: 1 }}>
-                    <View style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: getColor(backgroundColor), alignItems:'center', justifyContent: 'center' }}>
+                    <View style={{ width: size, height: size, borderRadius: borderRadius, backgroundColor: getColor(backgroundColor), alignItems:'center', justifyContent: 'center' }}>
                         <Icon
                             name={icon}
                             color={color}
@@ -51,7 +67,7 @@ export default class Avatar extends Component {
         if (text) {
             return (
                 <View style={{ flex: 1 }}>
-                    <View style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: getColor(backgroundColor), alignItems:'center', justifyContent: 'center' }}>
+                    <View style={{ width: size, height: size, borderRadius: borderRadius, backgroundColor: getColor(backgroundColor), alignItems:'center', justifyContent: 'center' }}>
                         <Text style={{ color: color }}>{text}</Text>
                     </View>
                 </View>


### PR DESCRIPTION
Since Material Design [guidelines] (https://www.google.com/design/spec/style/icons.html) allow both rounded and square icons, I changed border style defaults into props to allow `border radius, color and width` styling.