### PR TITLE
Updated propTypes of Card, Divider, Icon and Toolbar to propTypes.style

### DIFF
--- a/lib/Card/index.js
+++ b/lib/Card/index.js
@@ -20,7 +20,7 @@ export default class Card extends Component {
         disabled: PropTypes.bool,
         onPress: PropTypes.func,
         children: PropTypes.node.isRequired,
-        style: PropTypes.object
+        style: View.propTypes.style
     };
 
     static defaultProps = {

--- a/lib/Divider.js
+++ b/lib/Divider.js
@@ -6,7 +6,7 @@ export default class Divider extends Component {
     static propTypes = {
         inset: PropTypes.bool,
         theme: PropTypes.oneOf(THEME_NAME),
-        style: PropTypes.object
+        style: View.propTypes.style
     };
 
     static defaultProps = {

--- a/lib/Icon.js
+++ b/lib/Icon.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react-native';
+import React, { Component, PropTypes, View} from 'react-native';
 import { default as VectorIcon } from 'react-native-vector-icons/MaterialIcons';
 import { getColor } from './helpers';
 
@@ -6,7 +6,7 @@ export default class Icon extends Component {
 
     static propTypes = {
         name: PropTypes.string.isRequired,
-        style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+        style: View.propTypes.style,
         size: PropTypes.number,
         color: PropTypes.string
     };

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -10,7 +10,7 @@ export default class Toolbar extends Component {
         title: PropTypes.string,
         theme: PropTypes.oneOf(THEME_NAME),
         primary: PropTypes.oneOf(PRIMARY_COLORS),
-        style: PropTypes.object,
+        style: View.propTypes.style,
         leftIconStyle: PropTypes.object,
         rightIconStyle: PropTypes.object,
         elevation: PropTypes.number,


### PR DESCRIPTION
This avoids getting warnings when applying arrays of objects to Cards, and allows a slightly cleaner syntax than 
PropTypes.oneOfType([PropTypes.object, PropTypes.array])

