### PR TITLE
Fix IOS button styles not having shadow and having incorrectly vertically aligned text

### DIFF
--- a/lib/Button.js
+++ b/lib/Button.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes, View, Text, TouchableNativeFeedback } from 'react-native';
+import React, { Component, PropTypes, View, Text, TouchableNativeFeedback, Platform} from 'react-native';
 import Ripple from './polyfill/Ripple';
 import { TYPO, PRIMARY, THEME_NAME, PRIMARY_COLORS } from './config';
 import { getColor, isCompatible } from './helpers';
@@ -199,13 +199,13 @@ export default class Button extends Component {
                         styles.button,
                         buttonStyle, {
                             backgroundColor: buttonStyle && buttonStyle.backgroundColor,
-                        }, raised && !isCompatible('elevation') && {
+                        }, raised && !isCompatible('elevation') && Platform.OS !== 'ios' && {
                             borderWidth: 1,
                             borderColor: 'rgba(0,0,0,.12)'
                         }
                     ]}
                 >
-                    <Text style={[TYPO.paperFontButton, textStyle]}>
+                    <Text style={[TYPO.paperFontButton, textStyle, styles.text]}>
                         {text || value}
                     </Text>
                 </Ripple>
@@ -248,6 +248,6 @@ const styles = {
     },
     text: {
         position: 'relative',
-        top: 2
+        top: Platform.os === 'android' ? 2 : -4
     }
 };

--- a/lib/polyfill/Elevation.js
+++ b/lib/polyfill/Elevation.js
@@ -1,0 +1,23 @@
+import {Platform} from 'react-native'
+
+export default function (elevation){
+	if(Platform.OS == 'ios'){
+		if(elevation !== 0){
+			return {
+				shadowColor: "black",
+				shadowOpacity: 0.3,
+				shadowRadius: elevation,
+				shadowOffset: {
+					height: 2,
+					width: 0
+				}
+			}
+		}else{
+			return {}
+		}
+	}else{
+		return {
+			elevation: elevation,
+		}
+	}
+}

--- a/lib/polyfill/Ripple.js
+++ b/lib/polyfill/Ripple.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes, View, Animated, TouchableOpacity } from 'react-native';
+import elevationPolyfill from './Elevation';
 
 export default class Ripple extends Component {
 
@@ -45,8 +46,7 @@ export default class Ripple extends Component {
                 onPressOut={this._unHighlight}
             >
                 <View
-                    style={style || {}}
-                    elevation={elevation ? elevation : 0}
+                    style={[style || {}, elevationPolyfill(elevation ? elevation : 0)]}
                 >
                     <Animated.View  style={[
                         styles.background, {


### PR DESCRIPTION
Hey,

I'm using the material design elements on IOS and I noticed that the buttons were a little off, so I've fixed them :D

Before:
![button_before](https://cloud.githubusercontent.com/assets/296106/15038191/ce161616-12e0-11e6-9a26-65f285b98b82.png)

After:
![button_after](https://cloud.githubusercontent.com/assets/296106/15038190/cdabf844-12e0-11e6-8e3f-9454f18e1a1d.png)


Thanks!