### PR TITLE
Fix typo in platform detection

### DIFF
--- a/lib/Button.js
+++ b/lib/Button.js
@@ -248,6 +248,6 @@ const styles = {
     },
     text: {
         position: 'relative',
-        top: Platform.os === 'android' ? 2 : -4
+        top: Platform.OS === 'android' ? 2 : -4
     }
 };


### PR DESCRIPTION
Sorry guys :(

my last pull request had a typo in `Platform.os` -> `Platform.OS` so it always defaulted to the IOS button positioning


Thanks!