### PR TITLE
Fix depreciation warnings about importing React from React-Native package

### DIFF
--- a/lib/Avatar.js
+++ b/lib/Avatar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Image, Text } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, Image, Text} from "react-native";
 import Icon from './Icon';
 import { getColor } from './helpers';
 

--- a/lib/Button.js
+++ b/lib/Button.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Text, TouchableNativeFeedback, Platform} from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, Text, TouchableNativeFeedback, Platform} from "react-native";
 import Ripple from './polyfill/Ripple';
 import { TYPO, PRIMARY, THEME_NAME, PRIMARY_COLORS } from './config';
 import { getColor, isCompatible } from './helpers';

--- a/lib/Card/Actions.js
+++ b/lib/Card/Actions.js
@@ -1,4 +1,5 @@
-import React, { Component, StyleSheet, PropTypes, View } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, View} from "react-native";
 
 export default class Actions extends Component {
 

--- a/lib/Card/Body.js
+++ b/lib/Card/Body.js
@@ -1,4 +1,5 @@
-import React, { Component, StyleSheet, PropTypes, View } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, View} from "react-native";
 
 export default class Body extends Component {
 

--- a/lib/Card/Media.js
+++ b/lib/Card/Media.js
@@ -1,4 +1,5 @@
-import React, { Component, StyleSheet, PropTypes, Image, View } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, Image, View} from "react-native";
 
 export default class Media extends Component {
 

--- a/lib/Card/index.js
+++ b/lib/Card/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, TouchableNativeFeedback } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, TouchableNativeFeedback} from "react-native";
 import Ripple from '../polyfill/Ripple';
 import { getColor, isCompatible } from '../helpers';
 

--- a/lib/Checkbox.js
+++ b/lib/Checkbox.js
@@ -1,4 +1,5 @@
-import React, { Component, StyleSheet, PropTypes, Text, View, TouchableHighlight } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, Text, View, TouchableHighlight} from "react-native";
 import { TYPO, PRIMARY, COLOR, PRIMARY_COLORS, THEME_NAME } from './config';
 import Icon from './Icon';
 import IconToggle from './IconToggle';

--- a/lib/CheckboxGroup.js
+++ b/lib/CheckboxGroup.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View} from "react-native";
 import Checkbox from './Checkbox';
 import { THEME_NAME, PRIMARY, PRIMARY_COLORS } from './config';
 

--- a/lib/Divider.js
+++ b/lib/Divider.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View} from "react-native";
 import { THEME_NAME } from './config';
 
 export default class Divider extends Component {

--- a/lib/Drawer/Header.js
+++ b/lib/Drawer/Header.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Image } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, Image} from "react-native";
 
 export default class Header extends Component {
 

--- a/lib/Drawer/Section.js
+++ b/lib/Drawer/Section.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Text, TouchableNativeFeedback } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, Text, TouchableNativeFeedback} from "react-native";
 import Icon from '../Icon';
 import Ripple from '../polyfill/Ripple';
 import { TYPO } from '../config';

--- a/lib/Drawer/index.js
+++ b/lib/Drawer/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, ScrollView } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {ScrollView} from "react-native";
 import { THEME_NAME, PRIMARY_COLORS } from '../config';
 import { getColor } from '../helpers';
 

--- a/lib/Icon.js
+++ b/lib/Icon.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View} from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View} from "react-native";
 import { default as VectorIcon } from 'react-native-vector-icons/MaterialIcons';
 import { getColor } from './helpers';
 

--- a/lib/Icon.js
+++ b/lib/Icon.js
@@ -9,16 +9,18 @@ export default class Icon extends Component {
         name: PropTypes.string.isRequired,
         style: View.propTypes.style,
         size: PropTypes.number,
-        color: PropTypes.string
+        color: PropTypes.string,
+        allowFontScaling: PropTypes.bool
     };
 
     static defaultProps = {
         size: 30,
-        color: '#757575'
+        color: '#757575',
+        allowFontScaling: true
     };
 
     render() {
-        const { name, style, size, color } = this.props;
+        const { name, style, size, color, allowFontScaling} = this.props;
 
         return (
             <VectorIcon
@@ -26,6 +28,7 @@ export default class Icon extends Component {
                 size={size}
                 color={getColor(color)}
                 style={style}
+                allowFontScaling={allowFontScaling}
             />
         );
     }

--- a/lib/IconToggle.js
+++ b/lib/IconToggle.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Text, View, Animated } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {Text, View, Animated} from "react-native";
 import { getColor } from './helpers';
 
 export default class IconToggle extends Component {

--- a/lib/List.js
+++ b/lib/List.js
@@ -1,4 +1,5 @@
-import React, { Component, StyleSheet, PropTypes, View, Text, TouchableWithoutFeedback } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, View, Text, TouchableWithoutFeedback} from "react-native";
 import { TYPO } from './config';
 
 export default class List extends Component {

--- a/lib/RadioButton.js
+++ b/lib/RadioButton.js
@@ -1,4 +1,5 @@
-import React, { Component, StyleSheet, PropTypes, Text, View, TouchableHighlight } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, Text, View, TouchableHighlight} from "react-native";
 import Icon from './Icon';
 import IconToggle from './IconToggle';
 import { TYPO, PRIMARY, COLOR, THEME_NAME, PRIMARY_COLORS } from './config';

--- a/lib/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View} from "react-native";
 import RadioButton from './RadioButton';
 import { PRIMARY, PRIMARY_COLORS, THEME_NAME } from './config';
 

--- a/lib/Ripple.js
+++ b/lib/Ripple.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Text, TouchableNativeFeedback } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, Text, TouchableNativeFeedback} from "react-native";
 import { default as PolyfillRipple } from './polyfill/Ripple';
 import { isCompatible } from './helpers';
 

--- a/lib/Subheader.js
+++ b/lib/Subheader.js
@@ -1,4 +1,5 @@
-import React, { Component, StyleSheet, PropTypes, View, Text } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {StyleSheet, View, Text} from "react-native";
 import { TYPO, THEME_NAME } from './config';
 import { getColor } from './helpers';
 

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Text } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, Text} from "react-native";
 import { TYPO, PRIMARY, THEME_NAME, PRIMARY_COLORS } from './config';
 import { getColor } from './helpers';
 import Icon from './Icon';

--- a/lib/polyfill/Ripple.js
+++ b/lib/polyfill/Ripple.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Animated, TouchableOpacity } from 'react-native';
+import React, {Component, PropTypes} from "react";
+import {View, Animated, TouchableOpacity} from "react-native";
 import elevationPolyfill from './Elevation';
 
 export default class Ripple extends Component {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/react-native-material-design/react-native-material-design",
   "dependencies": {
     "react-native-material-design-styles": "https://github.com/react-native-material-design/react-native-material-design-styles.git",
-    "react-native-vector-icons": "^1.0.3"
+    "react-native-vector-icons": "^2.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",


### PR DESCRIPTION
Requiring React API from react-native is now deprecated from 0.25
https://github.com/facebook/react-native/commit/0b534d1c3da9e3520bfd9b85bdd669db4d8c3b9f
https://github.com/facebook/react-native/commit/2eafcd45dbd42f750df1ab9aa3770fed5cdf11ae
https://github.com/facebook/react-native/releases/tag/v0.25.1

Used https://github.com/sibeliusseraphini/codemod-RN24-to-RN25

fixes: https://github.com/react-native-material-design/react-native-material-design/issues/61

Thanks,