### PR TITLE
Fix IOS ripple expanding outside of the container

### DIFF
--- a/lib/polyfill/Ripple.js
+++ b/lib/polyfill/Ripple.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes, View, Animated, TouchableOpacity } from 'react-native';
+import React, { Component, PropTypes, View, Animated, TouchableOpacity, Platform} from 'react-native';
 import elevationPolyfill from './Elevation';
 
 export default class Ripple extends Component {
@@ -35,10 +35,33 @@ export default class Ripple extends Component {
     render() {
         const { rippleColor, onPress, onLongPress, children, style } = this.props;
         const { fadeValue ,size, pageX, pageY, rippling, scaleValue, location, elevation } = this.state;
+        let outerStyle = {}, innerStyle = style;
+
+        // Extract padding, margin from style since IOS overflow: hidden has issues with the shadow
+        if(Platform.OS == 'ios') {
+            ({outerStyle, innerStyle} = (style instanceof Array ? style : [style]).reduce((obj, styles) => {
+                if (styles !== null) {
+                    Object.entries(styles).forEach(
+                        ([name, value]) =>
+                            [
+                                'marginLeft',
+                                'marginRight',
+                                'marginTop',
+                                'marginBottom',
+                                'marginHorizontal',
+                                'marginVertical',
+                                'margin',
+                                'borderRadius',
+                                'backgroundColor'
+                            ].indexOf(name) !== -1 ? obj.outerStyle[name] = value : obj.innerStyle[name] = value
+                    )
+                }
+                return obj
+            }, {outerStyle: {}, innerStyle: {}}));
+        }
 
         return (
             <TouchableOpacity
-                ref='container'
                 activeOpacity={1}
                 onPress={onPress}
                 onLongPress={onLongPress}
@@ -46,30 +69,33 @@ export default class Ripple extends Component {
                 onPressOut={this._unHighlight}
             >
                 <View
-                    style={[style || {}, elevationPolyfill(elevation ? elevation : 0)]}
+                    style={[elevationPolyfill(elevation ? elevation : 0), outerStyle]}
                 >
-                    <Animated.View  style={[
-                        styles.background, {
-                            backgroundColor: rippling ? rippleColor : 'transparent',
-                            opacity: fadeValue
-                        }
-                    ]}/>
-                    <Animated.View style={[
-                        styles.ripple,
-                        location &&
+                    <View ref="container" style={[styles.container, innerStyle]}>
+                        {children}
+                        <Animated.View  style={[
+                            styles.background, {
+                                backgroundColor: rippling ? rippleColor : 'transparent',
+                                opacity: fadeValue
+                            }
+                        ]}/>
+                        <Animated.View style={[
+                            styles.ripple,
+                            location &&
+                                {
+                                    backgroundColor: rippleColor,
+                                    width: size,
+                                    height: size,
+                                    top: pageY - location.pageY - size / 2,
+                                    left: pageX - location.pageX - size / 2,
+                                    borderRadius: size / 2
+                                },
                             {
-                                backgroundColor: rippleColor,
-                                width: size,
-                                height: size,
-                                top: pageY - location.pageY - size / 2,
-                                left: pageX - location.pageX - size / 2,
-                                borderRadius: size / 2
-                            },
-                        {
-                            transform: [{ scale: scaleValue }]
-                        }]}
-                    />
-                    {children}
+                                transform: [{ scale: scaleValue }]
+                            }]}
+                        />
+
+                    </View>
                 </View>
             </TouchableOpacity>
         );


### PR DESCRIPTION
Hi,

This pull request should fix the IOS ripple animation, while preserving the shadow

![ripple_ios](https://cloud.githubusercontent.com/assets/296106/15313482/b06200b2-1c4a-11e6-911e-480a36697489.gif)
![ripple_ios_fixed](https://cloud.githubusercontent.com/assets/296106/15313483/b0621502-1c4a-11e6-886b-4ee83e2da789.gif)

Thanks

Cheers,