### PR TITLE
Icon: Use Text.propTypes.style

### DIFF
--- a/lib/Icon.js
+++ b/lib/Icon.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes, View} from 'react-native';
+import React, { Component, PropTypes, Text} from 'react-native';
 import { default as VectorIcon } from 'react-native-vector-icons/MaterialIcons';
 import { getColor } from './helpers';
 
@@ -6,7 +6,7 @@ export default class Icon extends Component {
 
     static propTypes = {
         name: PropTypes.string.isRequired,
-        style: View.propTypes.style,
+        style: Text.propTypes.style,
         size: PropTypes.number,
         color: PropTypes.string
     };


### PR DESCRIPTION
Style attributes such as `fontSize` are only valid in a `Text` style object.
