### PR TITLE
Small tweak to allow children on Toolbar

### DIFF
--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -82,15 +82,19 @@ export default class Toolbar extends Component {
                         </IconToggle>
                     )
                 }
-                <Text
-                    numberOfLines={1}
-                    style={[styles.title, TYPO.paperFontTitle, {
-                        color: styleMap.color,
-                        marginLeft: icon ? styles.title.marginLeft : 16
-                    }]}
-                >
-                    {title}
-                </Text>
+                {
+                    !title ? this.props.children : (
+                        <Text
+                            numberOfLines={1}
+                            style={[styles.title, TYPO.paperFontTitle, {
+                                color: styleMap.color,
+                                marginLeft: icon ? styles.title.marginLeft : 16
+                            }]}
+                        >
+                            {title}
+                        </Text>
+                    )
+                }
                 {
                     actions &&
                     actions.map(function (action, i) {


### PR DESCRIPTION
Hi !

I've added a small line that makes it possible to specify children to the Toolbar Component to render them instead of the title :

```jsx

             <MaterialToolbar
                primary={'paperDeepPurple'}
                icon={'menu'}
                onIconPress={() => {
                    console.log('expected to open drawer');
                    drawer.openDrawer()
                }}
                actions={[{
                    icon: 'settings',
                    onPress: () => {
                        console.log('navbar right icon pressed')
                    }
                }]}
                rightIconStyle={{
                    margin: 10
                }}
            >
                     <TextInput
                        style={{height: 40, color: 'white', borderColor: 'gray', borderWidth: 1 ,flex: 1}}
                        onChangeText={(text) => {
                            console.log('text typed on top search bar : ' + text)
                        }}
                        value={"Search"}
                    />
            </MaterialToolbar>

```

![alt tag](http://i.imgur.com/aTY32LD.png)