### PR TITLE
iOS bugfix: Check styles instance of Object

### DIFF
--- a/lib/polyfill/Ripple.js
+++ b/lib/polyfill/Ripple.js
@@ -42,7 +42,7 @@ export default class Ripple extends Component {
         // Extract padding, margin from style since IOS overflow: hidden has issues with the shadow
         if(Platform.OS == 'ios') {
             ({outerStyle, innerStyle} = (style instanceof Array ? style : [style]).reduce((obj, styles) => {
-                if (styles !== null) {
+                if (styles instanceof Object) {
                     Object.entries(styles).forEach(
                         ([name, value]) =>
                             [


### PR DESCRIPTION
When styles is not null but is not an Object then Object.entries fails. Perform an instanceof check before calling Object.entries