### PR TITLE
Fix CheckGroup onSelect to return latest checked state - fixes #75

### DIFF
--- a/lib/CheckboxGroup.js
+++ b/lib/CheckboxGroup.js
@@ -65,22 +65,23 @@ export default class CheckboxGroup extends Component {
     _onChange = (checked, value) => {
         const { selected } = this.state;
 
+        var newSelected;
         if (checked) {
-            this.setState({
-                selected: [...selected, value]
-            });
+            newSelected = [...selected, value]
         } else {
             let index = selected.indexOf(value);
-            this.setState({
-                selected: [
-                    ...selected.slice(0, index),
-                    ...selected.slice(index + 1)
-                ]
-            });
+            newSelected = [
+                ...selected.slice(0, index),
+                ...selected.slice(index + 1)
+            ]
         }
 
+        this.setState({
+            selected: newSelected
+        });
+
         const { onSelect } = this.props;
-        onSelect && onSelect(this.value);
+        onSelect && onSelect(newSelected);
     };
 
     /**


### PR DESCRIPTION
I noticed this behavior broke when upgrading to RN 0.26 from RN 0.24 and from version 0.3.3 to 0.3.6 of this lib. Since setState behavior is no longer synchronous, we pass the newSelected directly instead of relying on setState. Thanks for your library!
