### PR TITLE
Add support for Exponent by making the Icon component injectable

### DIFF
--- a/lib/Icon.js
+++ b/lib/Icon.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from "react";
 import {View} from "react-native";
-import { default as VectorIcon } from 'react-native-vector-icons/MaterialIcons';
 import { getColor } from './helpers';
+import VectorIconComponent from './VectorIconComponent';
 
 export default class Icon extends Component {
 
@@ -21,6 +21,7 @@ export default class Icon extends Component {
 
     render() {
         const { name, style, size, color, allowFontScaling} = this.props;
+        const VectorIcon = VectorIconComponent.get();
 
         return (
             <VectorIcon

--- a/lib/VectorIconComponent.js
+++ b/lib/VectorIconComponent.js
@@ -1,0 +1,13 @@
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+
+let _iconComponent = MaterialIcons;
+
+export default {
+  set(component) {
+    _iconComponent = component;
+  },
+
+  get() {
+    return _iconComponent;
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,3 +14,4 @@ export { default as Ripple } from './Ripple';
 export { default as RadioButtonGroup } from './RadioButtonGroup';
 export { default as Subheader } from './Subheader';
 export { default as Toolbar } from './Toolbar';
+export { default as VectorIconComponent } from './VectorIconComponent';


### PR DESCRIPTION
Hi there! We've had people ask about using this library with [Exponent](https://getexponent.com) so I went ahead and patched it so that they play nicely together :)

After this patch, if people want to use it with Exponent they can just do this during app initialization:

```
import MaterialIcons from 'exponent-vector-icons/MaterialIcons';
import { VectorIconComponent } from 'react-native-material-design';
VectorIconComponent.set(MaterialIcons);
```