### PR TITLE
Allow the RadioButton label to be able to display a view element

### DIFF
--- a/lib/RadioButton.js
+++ b/lib/RadioButton.js
@@ -9,7 +9,7 @@ const typos = StyleSheet.create(TYPO);
 export default class RadioButton extends Component {
 
     static propTypes = {
-        label: PropTypes.string,
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
         theme: PropTypes.oneOf(THEME_NAME),
         primary: PropTypes.oneOf(PRIMARY_COLORS),
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
@@ -101,18 +101,21 @@ export default class RadioButton extends Component {
                         />
                     </IconToggle>
                     <View style={styles.labelContainer}>
-                        <Text
+                        {typeof(this.props.label) !== 'string'
+                            ? this.props.label
+                            :	<Text
                             style={[
-                                typos.paperFontBody1,
-                                styles.label,
-                                COLOR[`${theme}PrimaryOpacity`],
-                                disabled && COLOR[`${theme}DisabledOpacity`], {
-                                    color: LABEL_COLOR
-                                }
-                            ]}
+										typos.paperFontBody1,
+										styles.label,
+										COLOR[`${theme}PrimaryOpacity`],
+										disabled && COLOR[`${theme}DisabledOpacity`], {
+											color: LABEL_COLOR
+										}
+									]}
                         >
                             {this.props.label}
                         </Text>
+                        }
                     </View>
                 </View>
             </TouchableHighlight>

--- a/lib/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup.js
@@ -19,7 +19,7 @@ export default class RadioButtonGroup extends Component {
         selected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         items: PropTypes.arrayOf(PropTypes.shape({
             value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-            label: PropTypes.string,
+            label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
             disabled: PropTypes.bool
         }))
     };


### PR DESCRIPTION
I needed to display a complex label as part of the radio button. I've added support for displaying View elements as part of the label. The down side is that if choosing to do that will require manual handling of styling including disabled states
