### PR TITLE
Add loading state and style overrides to Button

### DIFF
--- a/lib/Button.js
+++ b/lib/Button.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from "react";
-import {View, Text, TouchableNativeFeedback, Platform} from "react-native";
+import {ActivityIndicator, View, Text, TouchableNativeFeedback, Platform} from "react-native";
 import Ripple from './polyfill/Ripple';
 import { TYPO, PRIMARY, THEME_NAME, PRIMARY_COLORS } from './config';
 import { getColor, isCompatible } from './helpers';
@@ -16,7 +16,14 @@ export default class Button extends Component {
             rippleColor: PropTypes.string
         }),
         disabled: PropTypes.bool,
+        loading: PropTypes.bool,
+        activityIndicatorColor: PropTypes.string,
         raised: PropTypes.bool,
+        styles: PropTypes.shape({
+            button:   View.propTypes.style,
+            disabled: View.propTypes.style,
+            text:     Text.propTypes.style
+        }),
         onPress: PropTypes.func,
         onLongPress: PropTypes.func,
     };
@@ -25,7 +32,12 @@ export default class Button extends Component {
         theme: 'light',
         primary: PRIMARY,
         disabled: false,
-        raised: false
+        loading: false,
+        raised: false,
+        activityIndicatorColor: 'black',
+        styles: {
+            disabled: {opacity: 0.5}
+        }
     };
 
     constructor(props) {
@@ -33,6 +45,15 @@ export default class Button extends Component {
         this.state = {
             elevation: 2
         };
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+        return (
+            nextProps.text     !== this.props.text ||
+            nextProps.value    !== this.props.value ||
+            nextProps.loading  !== this.props.loading ||
+            nextProps.disabled !== this.props.disabled
+        );
     }
 
     setElevation = () => {
@@ -49,7 +70,7 @@ export default class Button extends Component {
 
     render() {
         const { elevation } = this.state;
-        const { text, value, theme, primary, overrides, disabled, raised, onPress, onLongPress } = this.props;
+        const { text, value, theme, primary, overrides, disabled, loading, raised, styles, onPress, onLongPress } = this.props;
 
         const textStyleMap = {
             flat: {
@@ -172,19 +193,26 @@ export default class Button extends Component {
             return getColor(overrides.rippleColor)
         })();
 
-        if (disabled) {
+        if (disabled || loading) {
             return (
                 <View
                     style={[
-                        styles.button,
+                        componentStyles.button,
                         buttonStyle, {
                             backgroundColor: buttonStyle && buttonStyle.backgroundColor
-                        }
+                        },
+                        styles.button,
+                        styles.disabled
                     ]}
                 >
-                    <Text style={[TYPO.paperFontButton, textStyle, styles.text]}>
-                        {text || value}
-                    </Text>
+                    {loading ?
+                        <ActivityIndicator animating={this.props.loading} style={componentStyles.spinner} color={this.props.activityIndicatorColor} />
+                        :
+                        <Text style={[TYPO.paperFontButton, textStyle, componentStyles.text, styles.text]}>
+                            {text || value}
+                            {this.props.children}
+                        </Text>
+                    }
                 </View>
             );
         }
@@ -197,17 +225,19 @@ export default class Button extends Component {
                     onPress={!disabled ? onPress : null}
                     onLongPress={!disabled ? onLongPress : null}
                     style={[
-                        styles.button,
+                        componentStyles.button,
                         buttonStyle, {
                             backgroundColor: buttonStyle && buttonStyle.backgroundColor,
                         }, raised && !isCompatible('elevation') && Platform.OS !== 'ios' && {
                             borderWidth: 1,
                             borderColor: 'rgba(0,0,0,.12)'
-                        }
+                        },
+                        styles.button
                     ]}
                 >
-                    <Text style={[TYPO.paperFontButton, textStyle, styles.text]}>
+                    <Text style={[TYPO.paperFontButton, textStyle, componentStyles.text, styles.text]}>
                         {text || value}
+                        {this.props.children}
                     </Text>
                 </Ripple>
             )
@@ -222,13 +252,15 @@ export default class Button extends Component {
                 onPressOut={raised ? this.removeElevation : null}
             >
                 <View style={[
-                    styles.button,
+                    componentStyles.button,
                     buttonStyle, {
                         backgroundColor: buttonStyle && buttonStyle.backgroundColor,
                         elevation: raised ? elevation : 0
-                    }]}
+                    },
+                    styles.button
+                  ]}
                 >
-                    <Text style={[TYPO.paperFontButton, textStyle, styles.text]}>
+                    <Text style={[TYPO.paperFontButton, textStyle, componentStyles.text, styles.text]}>
                         {text || value}
                     </Text>
                 </View>
@@ -237,9 +269,8 @@ export default class Button extends Component {
     };
 }
 
-const styles = {
+const componentStyles = {
     button: {
-        height: 36,
         alignItems: 'center',
         justifyContent: 'center',
         paddingVertical: 6,
@@ -250,5 +281,8 @@ const styles = {
     text: {
         position: 'relative',
         top: Platform.OS === 'android' ? 2 : -4
+    },
+    spinner: {
+        alignSelf: 'center'
     }
 };

--- a/lib/polyfill/Ripple.js
+++ b/lib/polyfill/Ripple.js
@@ -25,7 +25,7 @@ export default class Ripple extends Component {
         elevation: PropTypes.array,
         onPress: PropTypes.func,
         onLongPress: PropTypes.func,
-        style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+        style: PropTypes.oneOfType([View.propTypes.style, PropTypes.object, PropTypes.array]),
         children: PropTypes.element.isRequired
     };
 


### PR DESCRIPTION
* Allows button to toggle loading state and display activity indicator
* Allows button to receive children
* Removes static button height
* Fixes Ripple style propType validation

I originally was going to submit two separate PRs, one for loading, and one for styles.  However, when merging one after the other, it would have given merge conflicts; so I decided to consolidate  :smile: