### PR TITLE
Fix flex use on checkbox label

### DIFF
--- a/lib/RadioButton.js
+++ b/lib/RadioButton.js
@@ -126,9 +126,11 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         backgroundColor: 'rgba(0,0,0,0)'
     },
+	labelContainer: {
+    	flex: 1
+	},
     label: {
         marginLeft: 16,
-        opacity: COLOR.darkPrimaryOpacity.opacity,
-        flex: 1
+        opacity: COLOR.darkPrimaryOpacity.opacity
     }
 });


### PR DESCRIPTION
Seems the checkbox label is looking wonky since the RN changes to `flex: 1` (I think it was RN 0.27?)

Before:
![before-fix](https://cloud.githubusercontent.com/assets/296106/17126184/e6027582-5339-11e6-938f-4e365a318d1c.png)

Fixed:
![after-fix](https://cloud.githubusercontent.com/assets/296106/17126185/e877d302-5339-11e6-9ef3-1af09b3ccb9b.png)
