### PR TITLE
Update scaling of IconToggle for rn 0.30

### DIFF
--- a/lib/IconToggle.js
+++ b/lib/IconToggle.js
@@ -7,7 +7,7 @@ export default class IconToggle extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            scaleValue: new Animated.Value(0.001),
+            scaleValue: new Animated.Value(0.01),
             opacityValue: new Animated.Value(0.1),
             maxOpacity: props.opacity,
             size: null
@@ -168,7 +168,7 @@ export default class IconToggle extends Component {
     _unHighlight = () => {
         if (!this.props.disabled) {
             Animated.timing(this.state.scaleValue, {
-                toValue: 0.001,
+                toValue: 0.01,
                 duration: 1500
             }).start();
             Animated.timing(this.state.opacityValue, {


### PR DESCRIPTION
Hey,

just upgraded to react native 0.30 and we've noticed that IconToggle is being shown with the bubble

it seems using the magic `0.001` no longer works... but `0.01` does
![icontoggle](https://cloud.githubusercontent.com/assets/296106/17128624/418fd3be-534d-11e6-89e4-1a03183713c5.png)
