### PR TITLE
Update ripple polyfil to support flex on the touchable

### DIFF
--- a/lib/polyfill/Ripple.js
+++ b/lib/polyfill/Ripple.js
@@ -26,12 +26,14 @@ export default class Ripple extends Component {
         onPress: PropTypes.func,
         onLongPress: PropTypes.func,
         style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-        children: PropTypes.element.isRequired
+        children: PropTypes.element.isRequired,
+        flexTouchable: PropTypes.bool
     };
 
     static defaultProps = {
         rippleColor: 'rgba(0,0,0,.2)',
-        elevation: null
+        elevation: null,
+        flexTouchable: false
     };
 
     render() {
@@ -69,6 +71,7 @@ export default class Ripple extends Component {
                 onLongPress={onLongPress}
                 onPressIn={this._highlight}
                 onPressOut={this._unHighlight}
+                style={this.props.flexTouchable ? styles.touchableFlexStyle : {}}
             >
                 <View
                     style={[elevationPolyfill(elevation ? elevation : 0), outerStyle]}
@@ -183,6 +186,9 @@ const styles = {
         left: 0
     },
     ripple: {
-        position: 'absolute'
+        position: 'absolute',
+    },
+    touchableFlexStyle: {
+       flex: 1
     }
 };


### PR DESCRIPTION
Hey,

I found that on IOS the TouchableOpacity won't respect the child flex (where TouchableNativeFeedback seems to) and that it sometimes requires a kick to force it to flex

pre flex
![touchable-pre](https://cloud.githubusercontent.com/assets/296106/17204545/4527d33e-54e5-11e6-913c-9fdbf6dad37a.png)

after flex
![touchable-after](https://cloud.githubusercontent.com/assets/296106/17204544/4526f676-54e5-11e6-9346-799e4a32d7c1.png)

(Trying to make the whole area a button)
