### PR TITLE
Pass onLayout through for Toolbar, IconToggle, and Toolbar actions.

### DIFF
--- a/lib/IconToggle.js
+++ b/lib/IconToggle.js
@@ -40,7 +40,8 @@ export default class IconToggle extends Component {
             animate: PropTypes.bool,
             backgroundColor: PropTypes.string,
             textColor: PropTypes.string
-        })
+        }),
+        onLayout: PropTypes.func
     };
 
     static defaultProps = {
@@ -59,7 +60,7 @@ export default class IconToggle extends Component {
 
     render() {
         const { scaleValue, opacityValue, size } = this.state;
-        const { color, children } = this.props;
+        const { color, onLayout, children } = this.props;
 
         let { badge } = this.props;
         let { percent } = this.props;
@@ -84,7 +85,7 @@ export default class IconToggle extends Component {
         this.badgeAnim = this.badgeAnim || new Animated.Value(0);
 
         return (
-            <View {...this._responder}>
+            <View {...this._responder} onLayout={onLayout}>
                 <View>
                     {size &&
                         <Animated.View

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -26,8 +26,10 @@ export default class Toolbar extends Component {
         actions: PropTypes.arrayOf(PropTypes.shape({
             icon: PropTypes.string.isRequired,
             onPress: PropTypes.func,
-            counter: PropTypes.shape()
-        }))
+            counter: PropTypes.shape(),
+            onLayout: PropTypes.func
+        })),
+        onLayout: PropTypes.func
     };
 
     static defaultProps = {
@@ -37,7 +39,7 @@ export default class Toolbar extends Component {
     };
 
     render() {
-        const { title, theme, primary, style, leftIconStyle, rightIconStyle, elevation, overrides, icon, onIconPress, actions } = this.props;
+        const { title, theme, primary, style, leftIconStyle, rightIconStyle, elevation, overrides, icon, onIconPress, actions, onLayout } = this.props;
 
         const themeMap = {
             light: {
@@ -67,7 +69,7 @@ export default class Toolbar extends Component {
         };
 
         return (
-            <View style={[styles.toolbar, { backgroundColor :styleMap.backgroundColor, elevation }, style]}>
+            <View style={[styles.toolbar, { backgroundColor :styleMap.backgroundColor, elevation }, style]} onLayout={onLayout}>
                 {
                     icon && (
                         <IconToggle
@@ -105,6 +107,7 @@ export default class Toolbar extends Component {
                                 badge={action.badge}
                                 onPress={action.onPress}
                                 disabled={action.disabled}
+                                onLayout={action.onLayout}
                             >
                                 <Icon name={action.icon}
                                       size={24}


### PR DESCRIPTION
Sometimes it's necessary to know where the toolbar and its actions are located, the standard way to do this in RN is with the `onLayout` handler. Nothing strange is done in Toolbar or the buttons, so passing onLayout through to the top view used for each should be good enough to support this.