### PR TITLE
Fix to checkbox to stay on middle

### DIFF
--- a/lib/Checkbox.js
+++ b/lib/Checkbox.js
@@ -136,5 +136,9 @@ const styles = StyleSheet.create({
         opacity: COLOR.darkPrimaryOpacity.opacity,
         alignItems: 'center',
         flex: 1
+    },
+    labelContainer :{
+        justifyContent: 'center',
+        flexDirection:'row'
     }
 });


### PR DESCRIPTION
In react native version 0.32.0, and android 5.0 the label doesn't stay on middle of line, that lines fix it