### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ Or view it online [here](https://appetize.io/app/hyp1m20y515c16cj5yw2karcjg)! (C
 npm i react-native-material-design --save
 ```
 
-Copy the `MaterialIcons` font file from [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons#android) to your local working directory:
+Follow the [Android installation instructions](https://github.com/oblador/react-native-vector-icons#android) on the [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) library, which consists of adding the following to your `./android/app/build.gradle`:
 
-`./node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf` -> `./android/app/src/main/assets/fonts`.
+```gradle
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
+```
+
+_Note: It's possible that the instructions on the react-native-vector-icons page differ from what is above. If that's the case, follow those instructions, and please file an issue with us to update it here._
 
 Import any required components into your project, for example:
 


### PR DESCRIPTION
  - Replace "copy font files" step with extending the build.gradle file with the fonts.gradle file in react-native-vector-icons
  - Allows for successful builds using react-native >0.18