### PR TITLE
Update button text to center align, RN 0.35 seems to have modified this

### DIFF
--- a/lib/Button.js
+++ b/lib/Button.js
@@ -279,8 +279,7 @@ const componentStyles = {
         borderRadius: 2
     },
     text: {
-        position: 'relative',
-        top: Platform.OS === 'android' ? 2 : -4
+        lineHeight: 20
     },
     spinner: {
         alignSelf: 'center'


### PR DESCRIPTION
Hey,

Seems the new RN modified something that messes up the button text alignment...

Before:
![button_broken](https://cloud.githubusercontent.com/assets/296106/19464768/7dc30a28-9546-11e6-894c-7f7d5b6214a1.png)

After fix:
![button_fixed](https://cloud.githubusercontent.com/assets/296106/19464770/7fa5be6c-9546-11e6-87cc-d0220c509bb3.png)

I've tried to simplify the button text positioning so it won't break in the future...
